### PR TITLE
Fix typo in execution command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The cli tool no one needs. Find out the weather for any city from your terminal
 
 1. Run
     ```sh
-    brew install weatherme`
+    brew install weatherme
     ```
 
 1. Enter `weatherme <city-name>` to see the weather in a city (use the `-a` flag for more granular weather details)


### PR DESCRIPTION
There was a lingering backtick after the command in step 2 "how to use" leftover from when this was changed from an inline code snip to a code block.